### PR TITLE
Replace Lasrifle Tercio with Storm Section in SA Pioneer Company Compulsory Detachments

### DIFF
--- a/app/data/formation_data.ts
+++ b/app/data/formation_data.ts
@@ -72,7 +72,7 @@ export const formationData: FORMATION[] = [
     name: "Solar Auxilia Pioneer Company",
     faction: FACTION.solar,
     allegiance: ALLEGIANCE.neutral,
-    compulsory: [1000, 9003, 1009, 1009],
+    compulsory: [1000, 9005, 1009, 1009],
     optional: [1002, 1001, 1008, 1003, 1003],
     choice: [[1005, 1007, 1008]],
   },

--- a/app/data/formation_slot_data.ts
+++ b/app/data/formation_slot_data.ts
@@ -106,4 +106,11 @@ export const formationSlotData: FORMATION_SLOT[] = [
     options: [9003],
     description: "Tank Commander",
   },
+  {
+    id: 9005,
+    type: DETACHMENT_TYPE.core,
+    restricted: true,
+    options: [2004],
+    description: "Storm Section",
+  },
 ];


### PR DESCRIPTION
The current view for the SA Pioneer company has the lasrifle tercio as one of the compulsory core units:

<img width="986" alt="image" src="https://github.com/JWTC2200/legionbuilder/assets/50462654/dfb9375a-dda9-483c-a3c6-ebc09b962572">

Instead, it should be HQ, two Bastions, and a compulsory core Storm Section:

<img width="524" alt="image" src="https://github.com/JWTC2200/legionbuilder/assets/50462654/0c9b843d-c21a-4589-bfb6-89832af26e50">


I created a new unique formation slot data for the mandatory Storm section, giving it the next id (9005), with the only option being 2004, which should be the storm section ID (from detachment_data). Replaced the 9003 in the compulsory section (which corresponds to the lasrifle tercio) with the new 9005 id of the storm section